### PR TITLE
Extend repl_send_goal to use the selected text as a goal even if not in a term

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,6 @@
         "out": true // set this to false to include "out" folder in search results
     },
     // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-    "typescript.tsc.autoDetect": "off"
+    "typescript.tsc.autoDetect": "off",
+    "hol-light.path": "/home/aqjune/hol-light"
 }

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A HOL Light extension for Visual Studio Code. It supports basic syntax highlight
 
 HOL Light should be installed separately. See [HOL Light repository](https://github.com/jrh13/hol-light/) for installation instructions. The path to a HOL Light installation should be manually set by modifying the `hol-light.path` option (it could be done by invoking the command `HOL Light: Set HOL Light Path` from the command palette).
 
-The extension is automatically activated for `.hl` files. If a HOL Light file has a different file type (e.g., `.ml`) then it is required to activate the HOL Light extension manually by selecting `HOL Light` language mode. 
+The extension is automatically activated for `.hl` files. If a HOL Light file has a different file type (e.g., `.ml`) then it is required to activate the HOL Light extension manually by selecting `HOL Light` language mode.
 
 It is also possible to associate `.ml` files with the HOL Light extension by executing the command `HOL Light: Associate .ml Files with HOL Light`. This command adds the following lines to the workspace settings file:
 ```
@@ -52,10 +52,10 @@ All commands can be invoked from the command palette or by pressing the correspo
 
     Starts a new HOL Light REPL. This command is automatically invoked whenever any HOL Light command is executed without an active HOL Light REPL.
 
-1) **HOL Light: Send selected text to HOL Light REPL** 
+1) **HOL Light: Send selected text to HOL Light REPL**
 
     Default shortcut: `Alt + E`
-    
+
     Sends selected text to HOL Light. If no text is selected, then text at the cursor position separated by `;;` is sent to HOL Light and the cursor position is moved to the next statement.
 
     A variation of this command is *HOL Light: Send Current Statement to REPL (no preprocessing)* (default shortcut `Ctrl + Alt + E`). This command sends the selected text to HOL Light without any preprocessing. It is useful when a server is used to execute statements and it is required to execute a module definition.
@@ -70,7 +70,7 @@ All commands can be invoked from the command palette or by pressing the correspo
 
     Default shortcut: `Alt + G`
 
-    Sets the term at the current cursor position as a new goal. This command works when the cursor is inside a HOL Light term (a text inside back quotes).
+    Sets the term at the current cursor position as a new goal. This command works when the cursor is inside a HOL Light term (a text inside back quotes). If the cursor is a selected text, the text is interpreted as an OCaml expression and passed as a parameter to the goal command.
 
 1) **HOL Light: Execute Current Tactic (Multiple Lines)**
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ All commands can be invoked from the command palette or by pressing the correspo
 
     Default shortcut: `Alt + G`
 
-    Sets the term at the current cursor position as a new goal. This command works when the cursor is inside a HOL Light term (a text inside back quotes). If the cursor is a selected text, the text is interpreted as an OCaml expression and passed as a parameter to the goal command.
+    Sets the term at the current cursor position as a new goal. This command works when the cursor is inside a HOL Light term (a text inside back quotes). If the selected text is not empty, the text is interpreted as an OCaml expression and passed as a parameter to the goal command.
 
 1) **HOL Light: Execute Current Tactic (Multiple Lines)**
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -51,7 +51,7 @@ export function activate(context: vscode.ExtensionContext) {
     async function chooseHOLLightPath() {
         const uri = await vscode.window.showOpenDialog({
             canSelectFiles: false,
-            canSelectFolders: true, 
+            canSelectFolders: true,
             canSelectMany: false
         });
         if (!uri || !uri.length || !uri[0].fsPath) {
@@ -89,7 +89,7 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(
         vscode.languages.registerHoverProvider(LANG_ID, util.combineHoverProviders(helpProvider, database, repl))
     );
-    
+
     context.subscriptions.push(
         vscode.languages.registerDefinitionProvider(LANG_ID, database)
     );
@@ -102,7 +102,7 @@ export function activate(context: vscode.ExtensionContext) {
     // Register notebook classes
     context.subscriptions.push(
         vscode.workspace.registerNotebookSerializer(
-            notebook.NOTEBOOK_TYPE, 
+            notebook.NOTEBOOK_TYPE,
             new notebook.HolNotebookSerializer(),
             // Output is not saved
             { transientOutputs: true }
@@ -186,7 +186,7 @@ export function activate(context: vscode.ExtensionContext) {
             await vscode.window.withProgress({
                     location: vscode.ProgressLocation.Notification,
                     cancellable: false
-            }, (progress, _token) => 
+            }, (progress, _token) =>
                 database.indexDocumentWithDependencies(
                     editor.document, holPath, rootPaths, true, progress));
         })
@@ -305,7 +305,7 @@ export function activate(context: vscode.ExtensionContext) {
                 const document = editor.document;
                 const selections = selection.splitStatements(document, { range: editor.selection });
                 const statements = selections.map(({ text, documentStart, documentEnd }) => ({
-                    cmd: text.trim(), 
+                    cmd: text.trim(),
                     options: { location: util.locationStartEnd(document, documentStart, documentEnd) }
                 })).filter(cmd => cmd.cmd);
                 repl.execute(statements);
@@ -320,7 +320,7 @@ export function activate(context: vscode.ExtensionContext) {
             //     const select = selection.selectStatement(editor.document, pos);
             // }
             // console.timeEnd('select statement');
-        
+
             // console.time('select statement2');
             // for (let i = 0; i < 100; i++) {
             //     const select = selection.selectStatement2(editor.document, pos);
@@ -330,7 +330,7 @@ export function activate(context: vscode.ExtensionContext) {
             repl.execute(statementSelection.text, {
                 location: util.locationStartEnd(editor.document, statementSelection.documentStart, statementSelection.documentEnd)
             });
-            
+
             if (statementSelection.newPos) {
                 editor.selection = new vscode.Selection(statementSelection.newPos, statementSelection.newPos);
                 editor.revealRange(editor.selection);
@@ -360,7 +360,7 @@ export function activate(context: vscode.ExtensionContext) {
             repl.execute(statementSelection.text, {
                 location: util.locationStartEnd(editor.document, statementSelection.documentStart, statementSelection.documentEnd)
             });
-            
+
             if (statementSelection.newPos) {
                 editor.selection = new vscode.Selection(statementSelection.newPos, statementSelection.newPos);
                 editor.revealRange(editor.selection);
@@ -377,7 +377,7 @@ export function activate(context: vscode.ExtensionContext) {
             terminal.show(true);
 
             const document = editor.document;
-            const selections = selection.splitStatements(document, { 
+            const selections = selection.splitStatements(document, {
                 range: new vscode.Range(document.positionAt(0), editor.selection.active),
                 parseLastStatement: true,
             });
@@ -415,6 +415,14 @@ export function activate(context: vscode.ExtensionContext) {
             // }
             // console.timeEnd('select goal');
 
+            if (!editor.selection.isEmpty) {
+              // Use the selected text as the goal.
+              let text = editor.document.getText(editor.selection)
+              const location = new vscode.Location(editor.document.uri, editor.selection);
+              repl.execute(`g(${text});;\n`, { location });
+              return;
+            }
+
             const term = selection.selectTerm(editor.document, pos);
             if (!term) {
                 vscode.window.showWarningMessage('Not inside a term');
@@ -450,7 +458,7 @@ export function activate(context: vscode.ExtensionContext) {
             repl.execute(`e(${editor.document.getText(selection.range)});;\n`, {
                 location: new vscode.Location(editor.document.uri, selection.range)
             });
-            newPos = selection.newline ? 
+            newPos = selection.newline ?
                 new vscode.Position(selection.range.end.line + 1, pos.character) :
                 new vscode.Position(selection.range.end.line, selection.range.end.character + 1);
         } else {
@@ -465,11 +473,11 @@ export function activate(context: vscode.ExtensionContext) {
     }
 
     context.subscriptions.push(
-        vscode.commands.registerTextEditorCommand('hol-light.repl_send_tactic_multline', 
+        vscode.commands.registerTextEditorCommand('hol-light.repl_send_tactic_multline',
                 editor => replSendTactic(editor, true, true)),
-        vscode.commands.registerTextEditorCommand('hol-light.repl_send_tactic_multline_no_newline', 
+        vscode.commands.registerTextEditorCommand('hol-light.repl_send_tactic_multline_no_newline',
                 editor => replSendTactic(editor, true, false)),
-        vscode.commands.registerTextEditorCommand('hol-light.repl_send_tactic', 
+        vscode.commands.registerTextEditorCommand('hol-light.repl_send_tactic',
                 editor => replSendTactic(editor, false, true)),
         vscode.commands.registerTextEditorCommand('hol-light.repl_send_tactic_no_newline',
                 editor => replSendTactic(editor, false, false))


### PR DESCRIPTION
This patch extends `repl_send_goal` to use the selected text as a goal even if the selection is outside a term, when the selection is not empty.

This is useful when the goal term is not defined as a constant but stored in an OCaml variable. This frequently happens in s2n-bignum because it needs to prove a theorem that has to be dynamically built on the fly

```
let t = `1 + 1 = 2`;;

prove(t, ...);; (* Select 't' and press Alt+G ('repl_send_goal') *)
```