### PR TITLE
Let `repl_back_proof` highlight the previous tactic

### DIFF
--- a/src/executor.ts
+++ b/src/executor.ts
@@ -7,6 +7,9 @@ export interface CommandOptions {
     silent?: boolean;
     // This flag is true for commands entered in the terminal window directly
     interactive?: boolean;
+    // If this command manipulates the goal state, holCommand stores the
+    // corresponding command. Should be one of ["g", "e", "r", "b"]
+    holCommand?: string;
 }
 
 export interface Executor {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -417,9 +417,9 @@ export function activate(context: vscode.ExtensionContext) {
 
             if (!editor.selection.isEmpty) {
               // Use the selected text as the goal.
-              let text = editor.document.getText(editor.selection)
+              let text = editor.document.getText(editor.selection);
               const location = new vscode.Location(editor.document.uri, editor.selection);
-              repl.execute(`g(${text});;\n`, { location });
+              repl.execute(`g(${text});;\n`, { location, holCommand: "g" });
               return;
             }
 
@@ -429,7 +429,8 @@ export function activate(context: vscode.ExtensionContext) {
                 return;
             }
             repl.execute(`g(${term.text});;`, {
-                location: util.locationStartEnd(editor.document, term.documentStart, term.documentEnd)
+                location: util.locationStartEnd(editor.document, term.documentStart, term.documentEnd),
+                holCommand: "g"
             });
         })
     );
@@ -447,7 +448,7 @@ export function activate(context: vscode.ExtensionContext) {
             let text = editor.document.getText(editor.selection);
             text = text.replace(tacticRe, '').trim();
             const location = new vscode.Location(editor.document.uri, editor.selection);
-            repl.execute(`e(${text});;\n`, { location });
+            repl.execute(`e(${text});;\n`, { location, holCommand: "e" });
             return;
         }
         const maxLines = multiline ? config.getConfigOption(config.TACTIC_MAX_LINES, 30) : 1;
@@ -456,7 +457,8 @@ export function activate(context: vscode.ExtensionContext) {
         let newPos: vscode.Position;
         if (selection && !selection.range.isEmpty) {
             repl.execute(`e(${editor.document.getText(selection.range)});;\n`, {
-                location: new vscode.Location(editor.document.uri, selection.range)
+                location: new vscode.Location(editor.document.uri, selection.range),
+                holCommand: "e"
             });
             newPos = selection.newline ?
                 new vscode.Position(selection.range.end.line + 1, pos.character) :
@@ -499,7 +501,7 @@ export function activate(context: vscode.ExtensionContext) {
                 vscode.window.showErrorMessage('No HOL Light REPL');
                 return;
             }
-            repl.execute('b();;');
+            repl.execute('b();;', { holCommand: "b" });
             decorations.clearAll(editor.document.uri);
         })
     );
@@ -520,7 +522,7 @@ export function activate(context: vscode.ExtensionContext) {
                 vscode.window.showErrorMessage('No HOL Light REPL');
                 return;
             }
-            repl.execute('r(1);;');
+            repl.execute('r(1);;', { holCommand: "r" });
         })
     );
 


### PR DESCRIPTION
This is a patch that updates `repl_back_proof` to highlight the previous tactic that has been executed before.

This is useful when one applied one or more `repl_back_proof`, saw the backtraced goal state, and wants to understand what was the last tactic that caused the backtraced goal state.
To achieve this, HolClient now has `tacticLocHistory` which is a list of VSCode locations. This records text locations of tactics that are executed after goal setting so far.

This feature is enabled only when HOL Server is used, to add locations to `tacticLocHistory` only when `e` command was finished successfully.

Example:
```
prove(
  `forall x. x + 1 = x + 0 + 1`,  (* step 1. set this as a goal *)
  STRIP_TAC THEN (* step 2. run this tactic *)
  REWRITE_TAC[ADD_ASSOC] THEN (* step 3. run this tactic *)
          (* step 4. apply `repl_back_proof` using Alt+B, which will highlight 'STRIP_TAC'! *)
  REWRITE_TAC[ADD_0]
);;
```