### PR TITLE
Print the number of subgoals before '#' in HOL Client

### DIFF
--- a/src/hol_client.ts
+++ b/src/hol_client.ts
@@ -6,6 +6,7 @@ import * as config from './config';
 import { CommandDecorations, CommandDecorationType } from './decoration';
 import { Executor, CommandOptions, ProofCommand } from './executor';
 import { Repl } from './repl';
+import { stringify } from 'node:querystring';
 
 const LINE_END = '\n';
 
@@ -237,9 +238,16 @@ export class HolClient implements vscode.Pseudoterminal, Executor {
             // Process complete lines
             for (let i = 0; i < output.length - 1; i++) {
                 const line = output[i];
-                if (line === 'ready') {
+                if (line.startsWith('ready:')) {
+                    const readyInfo = unescapeString(line.slice(6));
                     if (!suppressPrompt) {
-                        this.writeEmitter.fire('# ');
+                        const subgoalsInfo = readyInfo.slice("subgoals:".length);
+                        var msg = '';
+                        if (!(subgoalsInfo === '')) {
+                          const ns = subgoalsInfo.split(',');
+                          msg = ns[0] + " subgoal" + (ns[0] === "1" ? "" : "s") + " (" + ns[1] + " total) ";
+                        }
+                        this.writeEmitter.fire(colorText(msg, 'blue') + '# ');
                     }
                     suppressPrompt = false;
                     this.currentCommand?.clear(this.decorations);


### PR DESCRIPTION
This updates hol_client to print the number of subgoals as well as total subgoals before '#'.

The numbers are already printed as something like "val it : goalstack = 2 subgoals (2 total)" when `g` or `e` is used in the basic HOL Light standard outputs. However, it quickly goes behind a screen as soon as the printed goal state is too long or extra OCaml commands like new definitions of tactics are executed. This patch helps track the subgoal numbers.

To achieve this, I updated server2.ml so that the 'ready' message contains this information. I reckoned that this was the easiest way to implement because otherwise an extra command for getting these numbers must have been enqueued and its results must have been properly cached at somewhere. Or, one can extract the subgoal numbers from the previous standard outputs when the command was e/g/b/r/etc, but since the executed tactic could have printed a custom message to the standard output (e.g., `REMARK_TAC`) this would require parsing the output text which can be fragile.

Though, it makes server2.ml now dependent on the global variables that are already loaded on HOL Light.