### PR TITLE
Use a new command 'er' when running a tactic in list, minor updates

### DIFF
--- a/src/decoration.ts
+++ b/src/decoration.ts
@@ -84,7 +84,7 @@ export class Decorations {
 
 class DecorationCollection {
     private decorations: Decorations[];
-    
+
     constructor(decorations: Decorations[]) {
         this.decorations = decorations;
     }
@@ -121,6 +121,7 @@ class DecorationCollection {
         this.decorations.forEach(ds => ds.removeRange(location));
     }
 
+    // Remove all decorations in the file pointed by uri.
     clear(decorationIndex: number, uri: vscode.Uri) {
         this.decorations[decorationIndex]?.clear(uri);
     }

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 
 import { CommandDecorations, CommandDecorationType } from './decoration';
 
-export type ProofCommand = 'g' | 'e' | 'r' | 'b';
+export type ProofCommand = 'g' | 'e' | 'r' | 'er' | 'b';
 
 export interface CommandOptions {
     location?: vscode.Location;
@@ -10,12 +10,12 @@ export interface CommandOptions {
     // This flag is true for commands entered in the terminal window directly
     interactive?: boolean;
     // If this command manipulates the goal state, proofCommand stores the
-    // corresponding command. Should be one of 'g' | 'e' | 'r' | 'b'
+    // corresponding command.
     proofCommand?: ProofCommand;
 }
 
 export function classifyProofCommand(cmd: string): ProofCommand | undefined {
-    const m = cmd.match(/^\s*([gerb])(?=[\(`]|\s+[\(\w`])/);
+    const m = cmd.match(/^\s*([gerb]|er)(?=[\(`]|\s+[\(\w`])/);
     if (m) {
         return m[1] as ProofCommand;
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -307,7 +307,7 @@ export function activate(context: vscode.ExtensionContext) {
                 const selections = selection.splitStatements(document, { range: editor.selection });
                 const statements = selections.map(({ text, documentStart, documentEnd }) => ({
                     cmd: text.trim(),
-                    options: { 
+                    options: {
                         location: util.locationStartEnd(document, documentStart, documentEnd),
                         proofCommand: classifyProofCommand(text),
                     }
@@ -391,7 +391,7 @@ export function activate(context: vscode.ExtensionContext) {
             });
             const statements = selections.map(({ text, documentStart, documentEnd }) => ({
                 cmd: text.trim(),
-                options: { 
+                options: {
                     location: util.locationStartEnd(document, documentStart, documentEnd),
                     proofCommand: classifyProofCommand(text),
                 },
@@ -467,10 +467,20 @@ export function activate(context: vscode.ExtensionContext) {
         const pos = editor.selection.active;
         let newPos: vscode.Position;
         if (selection && !selection.range.isEmpty) {
-            repl.execute(`e(${editor.document.getText(selection.range)});;\n`, {
-                location: new vscode.Location(editor.document.uri, selection.range),
-                proofCommand: 'e'
-            });
+            if (selection.endsWithSemicolon && repl.erSupportedByHOL()) {
+                // If the selected tactic ends with ';', this is a part of the tactic
+                // list after THENL. Use 'er' which rotates to the next subgoal after
+                // 'e tac'.
+                repl.execute(`er(${editor.document.getText(selection.range)});;\n`, {
+                    location: new vscode.Location(editor.document.uri, selection.range),
+                    proofCommand: 'er'
+                });
+            } else {
+                repl.execute(`e(${editor.document.getText(selection.range)});;\n`, {
+                    location: new vscode.Location(editor.document.uri, selection.range),
+                    proofCommand: 'e'
+                });
+            }
             newPos = selection.newline ?
                 new vscode.Position(selection.range.end.line + 1, pos.character) :
                 new vscode.Position(selection.range.end.line, selection.range.end.character + 1);

--- a/src/hol_client.ts
+++ b/src/hol_client.ts
@@ -91,7 +91,7 @@ class Command {
     // Location for providing feedback
     readonly location?: vscode.Location;
     // If this command manipulates the goal state, proofCommand stores the
-    // corresponding command. Should be one of ["g", "e", "r", "b"] or none.
+    // corresponding command.
     // Used for recovering text highlights of the previous tactics when b()ed.
     readonly proofCommand?: ProofCommand;
 
@@ -299,8 +299,10 @@ export class HolClient implements vscode.Pseudoterminal, Executor {
                         command.progressResolve?.();
 
                         if (command.location) {
-                            this.decorations.clear(err ? CommandDecorationType.success : CommandDecorationType.failure, command.location.uri);
-                            // this.decorations.addRange(this.decorations.success, command.location);
+                            if (!err) {
+                                // If there is no error, remove the previous failure highlight.
+                                this.decorations.clear(CommandDecorationType.failure, command.location.uri);
+                            }
                             this.decorations.setRange(err ? CommandDecorationType.failure : CommandDecorationType.success, command.location);
                         }
 
@@ -314,6 +316,9 @@ export class HolClient implements vscode.Pseudoterminal, Executor {
                                     this.tacticLocHistory = [];
                                     break;
                                 case 'e':
+                                    this.tacticLocHistory.push(command.location);
+                                    break;
+                                case 'er':
                                     this.tacticLocHistory.push(command.location);
                                     break;
                                 case 'b':

--- a/src/notebook.ts
+++ b/src/notebook.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import stripAnsi from 'strip-ansi';
 import { TextDecoder, TextEncoder } from 'node:util';
 
 import * as config from './config';
@@ -127,7 +128,7 @@ export class HolNotebookController {
             if (m) {
                 const name = m[1].trim();
                 const type = m[2].trim();
-                let body = m[3].trim();
+                let body = stripAnsi(m[3].trim());
                 output.push(vscode.NotebookCellOutputItem.text(`\`${name} : ${type}\``, 'text/markdown'));
                 if (type === 'thm' || type === 'term') {
                     body = type === 'thm' ? "```hol-light-ocaml\n`" + body + "`\n```" : "```hol-light-ocaml\n" + body + "\n```";


### PR DESCRIPTION
This patch has a few updates:

1. If 'er' is available on this HOL Light version, use it instead of 'e' when the tactic statement finishes with ';'.

- This is useful when one wants to execute tactics inside a tactic list, which typically follows after 'THENL'.
- https://github.com/jrh13/hol-light/pull/140 and the Help file https://github.com/jrh13/hol-light/blob/master/Help/er.hlp has more info.

2. Fix the code highlighting in HolClient to keep the last successful statements highlighted even if subsequent statements fail.

- The current behavior is that when any statement fails, the statement is highlighted as red, and the previous green statement is unhighlighted.
- This is dropping too much information I think; knowing what was the last successful statement seems useful.

3. Apply stripAnsi to the notebook output.