### PR TITLE
Add line number directive, add 'Connect to Server' button

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,11 @@
                 "title": "Start Server"
             },
             {
+              "category": "HOL Light",
+              "command": "hol-light.connect_server",
+              "title": "Connect to Server"
+            },
+            {
                 "category": "HOL Light",
                 "command": "hol-light.set_path",
                 "title": "Set HOL Light path"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -255,6 +255,13 @@ export function activate(context: vscode.ExtensionContext) {
     );
 
     context.subscriptions.push(
+        vscode.commands.registerCommand('hol-light.connect_server', async () => {
+            repl.dispose();
+            (await repl.connectServer())?.show(true);
+        })
+    );
+
+    context.subscriptions.push(
         vscode.commands.registerCommand('hol-light.set_path', chooseHOLLightPath)
     );
 

--- a/src/hol_client.ts
+++ b/src/hol_client.ts
@@ -395,7 +395,6 @@ export class HolClient implements vscode.Pseudoterminal, Executor {
         if (command.location) {
             this.decorations.addRange(CommandDecorationType.pending, command.location);
         }
-        // console.log(`executing: ${command.cmd}`);
         if (!command.silent) {
             vscode.window.withProgress({
                     location: vscode.ProgressLocation.Window,
@@ -414,7 +413,17 @@ export class HolClient implements vscode.Pseudoterminal, Executor {
         }
         this.readyFlag = false;
         this.currentCommand = command;
-        this.socket.write(escapeString(command.cmd));
+
+        // Add the line number directive, to save
+        let cmd = command.cmd;
+        if (command.location) {
+          const filepath = command.location.uri.fsPath;
+          const linenum = command.location.range.start.line + 1;
+          // There is no way to pass column to the line number directive of
+          // OCaml. :/
+          cmd = `#${linenum} "${filepath}"\n` + cmd;
+        }
+        this.socket.write(escapeString(cmd));
         this.socket.write(LINE_END);
     }
 

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -168,7 +168,7 @@ export class Repl implements Executor, vscode.Disposable, vscode.HoverProvider {
         this.clientTerminal = undefined;
         this.holClient = undefined;
         this.erAvailable = false;
-        
+
         this.holClient = new client.HolClient(address, port, this.decorations, this);
         this.clientTerminal = vscode.window.createTerminal({ name: 'HOL Light (client)', pty: this.holClient, isTransient: true });
 
@@ -316,6 +316,74 @@ export class Repl implements Executor, vscode.Disposable, vscode.HoverProvider {
         } else if (!this.getActiveTerminal() && Repl.defaultExecutor) {
             this.holTerminal = vscode.window.createTerminal({ name: 'HOL Light', isTransient: true });
             this.holExecutor = Repl.defaultExecutor;
+        }
+
+        this.updateStatusBarItem();
+        return this.getActiveTerminal();
+    }
+
+    async connectServer(_workDir: string = ''): Promise<vscode.Terminal | undefined> {
+        if (!this.getActiveTerminal() && !Repl.defaultExecutor) {
+            // let standardTerminal = false;
+            const paths = config.getConfigOption<string[]>(config.EXE_PATHS, []);
+            const serverDetail = `Address: ${config.getConfigOption(config.SERVER_ADDRESS, config.DEFAULT_SERVER_ADDRESS) || config.DEFAULT_SERVER_ADDRESS}`;
+            const serverLabel = 'Connect to a HOL Light server';
+            const serverItem: vscode.QuickPickItem = {
+                label: serverLabel,
+                detail: serverDetail,
+                buttons: [{ iconPath: new vscode.ThemeIcon('settings-gear'), tooltip: 'Change the address' }],
+            };
+
+            const result = await new Promise<vscode.QuickPickItem | null>((resolve, _reject) => {
+                const items: vscode.QuickPickItem[] = [];
+                items.push(serverItem);
+
+                let resolveOnHide = true;
+
+                const input = vscode.window.createQuickPick();
+                input.items = items;
+                input.placeholder = 'Connect to a HOL Light Server';
+
+                input.onDidHide(() => {
+                    if (resolveOnHide) {
+                        resolve(null);
+                        input.dispose();
+                    }
+                });
+
+                input.onDidTriggerItemButton(async (event) => {
+                    if (event.item === serverItem) {
+                        resolveOnHide = false;
+                        input.hide();
+                        const address = await config.getServerAddress({ showInputBox: true });
+                        if (address) {
+                            config.updateConfigOption(config.SERVER_ADDRESS, address.join(':'));
+                            serverItem.detail = `Address: ${address.join(':')}`;
+                        }
+                        resolveOnHide = true;
+                        input.items = items;
+                        input.show();
+                    }
+                });
+
+                input.onDidChangeSelection(items => {
+                    const item = items[0];
+                    resolve(item);
+                    input.hide();
+                });
+
+                input.show();
+            });
+
+            if (!result) {
+                return;
+            }
+
+            const address = await config.getServerAddress();
+            if (!address) {
+                return;
+            }
+            this.createHolClientTerminal(address[0], address[1], false);
         }
 
         this.updateStatusBarItem();


### PR DESCRIPTION
This patch includes addition of two different features:

1. Add line number directive to the beginning of every phrase sent to REPL

OCaml has a line number directive, e.g., `#100 "a.ml"` that is analogous to the line directive of C/C++.
If this is attached to the beginning of a phrase that is sent to REPL, it recognizes this and prints this when an exception is thrown & stack trace is enabled.

```
  # Printexc.record_backtrace true;;
..
  # #100 "a.ml"
    failwith "here";;

  Exception: Failure "here".
  Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
  Called from <unknown> in file "a.ml", line 100, characters 0-15
```

This is really useful in HOL Light if there is a tactic defined by a user and one wants to understand why it is failing.

The official HOL Light does not support a line directive yet, however, because the old version of camlp5 did not implement this, but since the latest 8.03.05 camlp5 now supports this directive it is a matter of time that this will be fixed in HOL Light. In fact, I already have a working version that supports this line directive:
  https://github.com/aqjune-aws/hol-light/tree/camlp5_8.03.05
After building this HOL Light with `make switch-5; eval $(opam env --set-switch); make`, `hol.sh` will support this line directive.

2. Add 'Connect to Server' feature

From a few vscode users I received a question about how to connect to a running HOL Light server; I found that it was indeed slighty confusing to find because I could connect through 'New HOL Light REPL Session'.
To address this, I added a 'shortcut' which is 'Connect to Server'. Its implementation is analogous to `getTerminalWindow` because I started from its copy.